### PR TITLE
Updated package to work with Webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-webpack-plugin",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Webpack middleware for Hapi. Supports HMR.",
   "homepage": "https://github.com/SimonDegraeve/hapi-webpack-plugin",
   "main": "./lib/index.js",
@@ -25,9 +25,9 @@
     "url": "https://github.com/SimonDegraeve/hapi-webpack-plugin/issues"
   },
   "dependencies": {
-    "webpack": "^1.12.9",
-    "webpack-dev-middleware": "^1.4.0",
-    "webpack-hot-middleware": "^2.6.0"
+    "webpack": "^2.2.0",
+    "webpack-dev-middleware": "^1.10.1",
+    "webpack-hot-middleware": "^2.17.1"
   },
   "devDependencies": {
     "babel": "^5.8.33",

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,15 @@
 
 [Webpack](http://webpack.github.io) middleware for [Hapi](https://github.com/hapijs/hapi). Supports HMR.
 
+
+
+## Webpack Version
+
+Please download the appropriate version for you. 
+
+* For **webpack 1.x** use version < 1.3.0 of this package.
+* For **webpack 2.x** use version >= 2.0.0 of this package.
+
 ## Installation
 
 ```js


### PR DESCRIPTION
Hi there @SimonDegraeve,

I noticed that #10 regarding [Webpack 2](https://webpack.js.org/guides/) compatibility was an outstanding issue. As such I've made minor changes to have the package work with Webpack 2.

Specifically:

- Webpack 2 and compatible middleware layers were added as dependencies.
- I also propose that this version of hapi-webpack-plugin be updated to version 2.0.0 as this would be a breaking change for users who are currently using the plugin with webpack 1. The change was made to version in the package.json.
- I've updated the package.json and the readme to correspond with this and give appropriate guidance to others who might choose to use this package in the future.

No changes were necessary to the plugin code itself itself. Ultimately all config options are passed on to the respective webpack middleware packages as was done previously. 

I've tested the plugin in my environment and it works for me. 

Note: 
- I've also left dev dependancies as is. A Babel 6 installation would require a different .babelrc and dev dependencies. However not knowing what environment you use yourself, I opted to leave these the same so as to (hopefully) make your acceptance of this pull request simple.

Do let me know if you have any questions. 