### PR TITLE
Virtual Host Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-webpack-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Webpack middleware for Hapi. Supports HMR.",
   "homepage": "https://github.com/SimonDegraeve/hapi-webpack-plugin",
   "main": "./lib/index.js",

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@
 
 Please download the appropriate version for you. 
 
-* For **webpack 1.x** use version < 1.3.0 of this package.
+* For **webpack 1.x** use version <= 1.3.0 of this package.
 * For **webpack 2.x** use version >= 2.0.0 of this package.
 
 ## Installation
@@ -133,11 +133,107 @@ export default {
 };
 ```
 
+**Virtual Hosts Binding**
+
+Hapi allows plugins to be bound to virtual hosts via the `routes.vhost` 
+option of [`server.register()`](https://hapijs.com/api#serverregisterplugins-options-callback). 
+As of version 2.0.1 this plugin supports binding a unqiue webpack configuration
+to a specific virtual host. Further, multiple instances of the plugin can be
+ registered simultaneously allowing for multiple unique webpack configurations to be running
+ for different virtual hosts on a single server.
+ 
+ ```js
+ /**
+  * file: index-vhost.js
+  */
+ 
+ /**
+  * Import dependencies
+  */
+ import {Server} from 'hapi';
+ import WebpackPlugin from 'hapi-webpack-plugin';
+ 
+ 
+ /**
+  * Create server
+  */
+ const server = new Server();
+ server.connection({port: 3000});
+ 
+ /**
+  * Register muliple plugin instances, one for each webpack/vhost combination, and start server
+  */
+ server.register([
+     {
+         register: WebpackPlugin,
+         options: './webpack.client.config.js',
+         routes: 
+         {
+             vhosts: 'client.mydomain.com'
+         }
+     },
+     {
+         register: WebpackPlugin,
+         options: './webpack.admin.config.js',
+         routes: 
+         {
+             vhosts: 'admin.mydomain.com'
+         }
+     }],
+     error => {
+       if (error) {
+         return console.error(error);
+       }
+       server.start(() => console.log('Server running at:', server.info.uri));
+     });
+ ```
+ ```js
+ /**
+  * file: webpack.client.config.js
+  */
+ 
+ /**
+  * Export webpack configuration for client
+  */
+ export default {
+   entry: 'client_app.js',
+ 
+   // webpack-dev-middleware options
+   // See https://github.com/webpack/webpack-dev-middleware
+   assets: {},
+ 
+   // webpack-hot-middleware options
+   // See https://github.com/glenjamin/webpack-hot-middleware
+   hot: {}
+ };
+ 
+ /**
+   * file: webpack.admin.config.js
+   */
+ 
+  /**
+   * Export webpack configuration for admin
+   */
+  export default {
+    entry: 'admin_app.js',
+  
+    // webpack-dev-middleware options
+    // See https://github.com/webpack/webpack-dev-middleware
+    assets: {},
+  
+    // webpack-hot-middleware options
+    // See https://github.com/glenjamin/webpack-hot-middleware
+    hot: {}
+  };
+ ```
+  
+  
+
 ## Licence
 
 The MIT License (MIT)
 
-Copyright (c) 2015 Simon Degraeve
+Copyright (c) 2017 Simon Degraeve
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hi @SimonDegraeve,

As mentioned in #13 I have modified plugin to support virtual hosts/route information if passed in. If no vhost specified passed in plugin behaves the same as before. Multiple instances of plugin, each for different vhost and different webpack configuration, are now supported. 

Ultimately there are no breaking changes for past users, but new functionality for those wishing to support more complex setups with vhosts.

The readme has been updated accordingly. 

Hopefully you can find some time push this one out soon. Let me know if you'd like me to modify adjust/anything further. I don't see any other changes being made to the plugin anytime soon (unless a bug is found). 