### PR TITLE
Support for Hapi 17.x

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "stage": 0,
-  "optional": []
+  "presets": ["env"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-webpack-plugin",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Webpack middleware for Hapi. Supports HMR.",
   "homepage": "https://github.com/SimonDegraeve/hapi-webpack-plugin",
   "main": "./lib/index.js",
@@ -25,14 +25,16 @@
     "url": "https://github.com/SimonDegraeve/hapi-webpack-plugin/issues"
   },
   "dependencies": {
-    "webpack": "^2.2.0",
-    "webpack-dev-middleware": "^1.10.1",
-    "webpack-hot-middleware": "^2.17.1"
+    "webpack": "^3.10.0",
+    "webpack-dev-middleware": "^2.0.1",
+    "webpack-hot-middleware": "^2.21.0"
   },
   "devDependencies": {
-    "babel": "^5.8.33",
-    "babel-eslint": "^4.1.6",
-    "eslint": "^1.10.3",
-    "eslint-plugin-babel": "^3.0.0"
+    "babel-cli": "^6.26.0",
+    "babel-eslint": "^8.0.3",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
+    "eslint": "^4.12.1",
+    "eslint-plugin-babel": "^4.1.2"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,12 @@
 
 Please download the appropriate version for you. 
 
+### **Hapi >= 17.x**
+* For **webpack >= 2.x** use version >= 3.0.0 of this package.
+
+### **Hapi <= 16.x**
 * For **webpack 1.x** use version < 1.3.0 of this package.
-* For **webpack 2.x** use version >= 2.0.0 of this package.
+* For **webpack 2.x** use version 2.x.x of this package.
 
 ## Installation
 
@@ -28,6 +32,69 @@ You can use the plugin in two ways.
 
 
 **1) With object as options**
+## **Hapi >= 17.x**
+```js
+/**
+ * file: index.js
+ */
+
+/**
+ * Import dependencies
+ */
+import {Server} from 'hapi';
+import Webpack from 'webpack';
+import WebpackPlugin from 'hapi-webpack-plugin';
+
+/**
+ * Create server
+ */
+const server = new Server({port: 3000});
+
+/**
+ * Define constants
+ */
+const compiler = new Webpack({
+  // webpack configuration
+  entry: 'app.js'
+});
+
+const assets = {
+  // webpack-dev-middleware options
+  // See https://github.com/webpack/webpack-dev-middleware
+}
+
+const hot = {
+  // webpack-hot-middleware options
+  // See https://github.com/glenjamin/webpack-hot-middleware
+}
+
+/**
+ * Register plugin and start server
+ */
+async function start() {
+  try {
+    await server.register({
+      plugin: WebpackPlugin,
+      options: {compiler, assets, hot}
+    });
+  }
+  catch (error) {
+    console.error(error);
+  }
+  
+  try {
+    server.start();
+    console.log('Server running at:', server.info.uri)
+  }
+  catch (error) {
+    console.error(error);
+  }
+}
+
+start();
+```
+
+## **Hapi <= 16.x**
 ```js
 /**
  * file: index.js
@@ -80,6 +147,51 @@ error => {
 ```
 
 **2) With path as options**
+## **Hapi >= 17**
+```js
+/**
+ * file: index.js
+ */
+
+/**
+ * Import dependencies
+ */
+import {Server} from 'hapi';
+import WebpackPlugin from 'hapi-webpack-plugin';
+
+
+/**
+ * Create server
+ */
+const server = new Server({port: 3000});
+
+/**
+ * Register plugin and start server
+ */
+async function start() {
+  try {
+    await server.register({
+      plugin: WebpackPlugin,
+      options: './webpack.config.js'
+    });
+  }
+  catch (error) {
+    console.error(error);
+  }
+  
+  try {
+    server.start();
+    console.log('Server running at:', server.info.uri)
+  }
+  catch (error) {
+    console.error(error);
+  }
+}
+
+start();
+```
+
+## **Hapi <= 16.x**
 ```js
 /**
  * file: index.js


### PR DESCRIPTION
Hi @SimonDegraeve 

As you might have noticed, **Hapi** with version **17** has recently moved to using async/await. This requires breaking changes to many plugins, this being one of them.

So we at Liaison Tech took the time to put together version **3.0.0** of **hapi-webpack-plugin** which works with **Hapi 17.x**.

All the dependencies have also been updated to the latest versions and the usage examples for **Hapi 17** added.

Let us know if you have any questions or concerns! :smile_cat: 