### PR TITLE
Version 3.1.0: update to using Webpack 4.x, and dev-middleware 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-webpack-plugin",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Webpack middleware for Hapi. Supports HMR.",
   "homepage": "https://github.com/SimonDegraeve/hapi-webpack-plugin",
   "main": "./lib/index.js",
@@ -25,9 +25,9 @@
     "url": "https://github.com/SimonDegraeve/hapi-webpack-plugin/issues"
   },
   "dependencies": {
-    "webpack": "^3.10.0",
-    "webpack-dev-middleware": "^2.0.1",
-    "webpack-hot-middleware": "^2.21.0"
+    "webpack": "^4.8.3",
+    "webpack-dev-middleware": "^3.1.3",
+    "webpack-hot-middleware": "^2.22.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
I upgraded the Webpack dependencies to 4.x and it seems to still work as expected.